### PR TITLE
feat: PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: "Publish: brunnr"
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[eval]" pytest
+      - run: python -m pytest tests/ -q
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 site/
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,16 @@ description = "Security scanner and skill registry for agent tool descriptions"
 requires-python = ">=3.12"
 license = "MIT"
 readme = "README.md"
+authors = [
+    { name = "Peleke Sengstacke" }
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Security",
+    "Topic :: Software Development :: Quality Assurance",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Tag-triggered publish to PyPI via trusted publisher (OIDC, no stored secrets)
- Tests run before build, build before publish
- Add author + classifiers to pyproject.toml
- Verified: `python -m build` produces clean wheel with only `brunnr/` package

## Setup required (one-time)

1. **PyPI**: Go to https://pypi.org/manage/account/publishing/ → Add a new pending publisher:
   - Package: `brunnr`
   - Owner: `Peleke`
   - Repository: `brunnr`
   - Workflow: `publish.yml`
   - Environment: `pypi`

2. **GitHub**: Go to repo Settings → Environments → Create `pypi` environment

## To publish

```bash
git tag v0.1.0
git push --tags
```

## Test plan
- [x] `python -m build` succeeds locally
- [x] Wheel contains only `brunnr/` package (no tests/docs/reviews)
- [ ] PyPI trusted publisher configured
- [ ] Tag push triggers workflow → publishes to PyPI
- [ ] `uv tool install brunnr && brunnr --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)