### PR TITLE
Add GitHub Release with auto-changelog + CHANGELOG.md

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,3 +44,41 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Generate changelog
+        id: changelog
+        run: |
+          # Find the previous tag
+          PREV_TAG=$(git tag --sort=-v:refname | head -2 | tail -1)
+          if [ "$PREV_TAG" = "${{ github.ref_name }}" ] || [ -z "$PREV_TAG" ]; then
+            # First release — changelog from all commits
+            echo "## What's Changed" > RELEASE_NOTES.md
+            git log --pretty=format:"- %s (%h)" >> RELEASE_NOTES.md
+          else
+            echo "## What's Changed" > RELEASE_NOTES.md
+            git log "${PREV_TAG}..HEAD" --pretty=format:"- %s (%h)" >> RELEASE_NOTES.md
+          fi
+          echo "" >> RELEASE_NOTES.md
+          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-initial}...${{ github.ref_name }}" >> RELEASE_NOTES.md
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --notes-file RELEASE_NOTES.md \
+            dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to brunnr will be documented in this file.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-03-11
+
+### Added
+- `brunnr scan` — pattern-based security scanner for agent tool descriptions (SKILL.md files)
+- `brunnr install` — fetch and install skills from the brunnr registry with review-before-install
+- `brunnr eval` — LLM-graded evaluation of tool descriptions against the ax-rubric
+- `brunnr pipeline` — combined scan + eval in a single pass
+- 26 built-in scan rules across 5 categories (prompt-injection, over-privilege, data-leak, ambiguity, missing-constraint)
+- `ax-rubric` skill — score tool descriptions 0-5 on discoverability
+- Claude Code plugin marketplace support (`.claude-plugin/marketplace.json`)
+- Path traversal protection in install command
+- MkDocs documentation site with ReadTheDocs theme
+- PyPI publishing via OIDC trusted publisher (tag-triggered)
+- GitHub Release with auto-generated changelog on tag push
+- 74 tests (55 scanner + 19 CLI)
+
+[Unreleased]: https://github.com/Peleke/brunnr/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Peleke/brunnr/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Adds a `release` job to the publish workflow that creates a GitHub Release with auto-generated changelog from commits since the previous tag
- Attaches built wheel + sdist to the release
- Adds `CHANGELOG.md` documenting the v0.1.0 release

## How it works
On tag push (`v*`), after PyPI publish succeeds:
1. Finds the previous tag
2. Generates changelog from `git log` between tags
3. Creates a GitHub Release with the notes + dist artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)