### PR TITLE
Add post-publish E2E smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,3 +82,32 @@ jobs:
             --title "${{ github.ref_name }}" \
             --notes-file RELEASE_NOTES.md \
             dist/*
+
+  smoke-test:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for PyPI propagation
+        run: sleep 30
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install from PyPI
+        run: pip install brunnr
+      - name: Verify version
+        run: brunnr --version
+      - name: Verify help
+        run: brunnr --help
+      - name: Install skill from registry
+        run: |
+          mkdir /tmp/brunnr-e2e && cd /tmp/brunnr-e2e
+          brunnr install ax-rubric --yes
+      - name: Scan installed skill
+        run: |
+          cd /tmp/brunnr-e2e
+          brunnr scan skills/
+      - name: Eval dry-run
+        run: |
+          cd /tmp/brunnr-e2e
+          brunnr eval ax-rubric --dry-run


### PR DESCRIPTION
## Summary
- Adds a `smoke-test` job to the publish workflow that runs after PyPI publish
- Installs brunnr from PyPI, then runs the full E2E: `--version`, `--help`, `install ax-rubric`, `scan`, `eval --dry-run`
- Catches packaging or registry issues before users hit them

## Test steps verified locally
1. `uv tool install brunnr` -> `brunnr 0.1.0`
2. `brunnr install ax-rubric --yes` -> success
3. `brunnr scan skills/` -> 1 file scanned
4. `brunnr eval ax-rubric --dry-run` -> DRY RUN

🤖 Generated with [Claude Code](https://claude.com/claude-code)