### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to brunnr will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-11
+
+### Fixed
+- README images now render on PyPI (absolute URLs instead of relative paths)
+- README install section shows both Claude Code marketplace and CLI paths
+
+### Added
+- Post-publish E2E smoke test in CI (installs from PyPI, runs install/scan/eval)
+- PyPI version badge
+
 ## [0.1.0] - 2026-03-11
 
 ### Added
@@ -20,5 +30,6 @@ All notable changes to brunnr will be documented in this file.
 - GitHub Release with auto-generated changelog on tag push
 - 74 tests (55 scanner + 19 CLI)
 
-[Unreleased]: https://github.com/Peleke/brunnr/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Peleke/brunnr/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/Peleke/brunnr/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Peleke/brunnr/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brunnr"
-version = "0.1.0"
+version = "0.1.1"
 description = "Security scanner and skill registry for agent tool descriptions"
 requires-python = ">=3.12"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.1
- Update CHANGELOG with v0.1.1 entries

Includes changes from PRs #14 and #15:
- Post-publish E2E smoke test in CI
- README images fixed for PyPI (absolute URLs)
- Dual install paths (Claude Code marketplace + CLI)
- PyPI version badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)