### PR TITLE
fix: trim runlet table cell + add Kanban implementer note

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ brunnr eval ax-rubric --dry-run
 |-------|-------------|----------|
 | **[ax-rubric](skills/ax-rubric/)** | Score tool descriptions 0-5 on agent discoverability. Five criteria, pass/fail, rewrite. | [I Don't Deliberate About This](https://peleke.me/writing/ax-04-tool-descriptions) |
 | **[ax-interview](skills/ax-interview/)** | Run a structured AX Interview on agent-tool sessions. Gricean maxim analysis, implicature detection, CoT faithfulness check, Pragmatic Coherence Score with ranked fixes. | [The AX Interview](https://peleke.me/writing/ax-07-the-ax-interview) |
-| **[runlet](skills/runlet/)** | Turn a braindump into an ND-adapted daily runlist. Classifies by activation energy and configurable focus axis. Entry points for high-activation tasks, carry-forward tracking, kill reasoning. | — |
+| **[runlet](skills/runlet/)** | Turn a braindump into an ND-adapted daily runlist. Classifies by activation energy and focus axis. | — |
 
 ---
 

--- a/skills/runlet/SKILL.md
+++ b/skills/runlet/SKILL.md
@@ -220,6 +220,8 @@ A markdown file at:
 *Carried items: N from YYYY-MM-DD.*
 ```
 
+> **Implementer note (Obsidian Kanban):** If the user views runlists in Obsidian Kanban, a `## Complete` lane should be appended after Kill or Delegate. The lane needs "Mark items in this list as complete" enabled (right-click lane header → toggle). This ensures dragging a card to Complete writes `- [x]` in the markdown, which the nightly recap agent reads to distinguish done from killed.
+
 ### Machine-readable summary
 
 Append an HTML comment block at the end of the file. This doesn't render in Obsidian but is readable by agents for the morning ping and nightly recap.


### PR DESCRIPTION
## Summary
- Trimmed the runlet row in the README skills table — was causing horizontal overflow
- Added Obsidian Kanban `## Complete` lane implementer note to `skills/runlet/SKILL.md`

## Test plan
- [ ] Verify README table renders without horizontal scroll on GitHub
- [ ] Verify SKILL.md blockquote note renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)