### PR TITLE
feat: CLI parity — registry, lockfile, 7 new commands, --target flag

### DIFF
--- a/brunnr/assertions.py
+++ b/brunnr/assertions.py
@@ -5,20 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-
-def parse_frontmatter(text: str) -> dict[str, str]:
-    """Extract YAML frontmatter from a SKILL.md file."""
-    if not text.startswith("---"):
-        return {}
-    parts = text.split("---", 2)
-    if len(parts) < 3:
-        return {}
-    fm = {}
-    for line in parts[1].strip().splitlines():
-        if ":" in line:
-            key, val = line.split(":", 1)
-            fm[key.strip()] = val.strip().strip('"').strip("'")
-    return fm
+from brunnr.frontmatter import parse_frontmatter  # noqa: F401 — re-export for backwards compat
 
 
 def extract_score(text: str) -> int | None:

--- a/brunnr/cli.py
+++ b/brunnr/cli.py
@@ -7,6 +7,8 @@ import sys
 
 from brunnr import __version__
 
+_DEFAULT_REGISTRY = "https://github.com/Peleke/brunnr"
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(
@@ -14,6 +16,7 @@ def main() -> int:
         description="Security scanner and skill registry for agent tool descriptions.",
     )
     parser.add_argument("--version", action="version", version=f"brunnr {__version__}")
+    parser.add_argument("--registry", default=_DEFAULT_REGISTRY, help="Skill registry URL")
     sub = parser.add_subparsers(dest="command")
 
     # --- brunnr scan ---
@@ -27,11 +30,14 @@ def main() -> int:
     # --- brunnr install ---
     inst_p = sub.add_parser("install", help="Install a skill from the registry")
     inst_p.add_argument("skill", nargs="?", help="Skill slug to install (e.g., ax-rubric)")
-    inst_p.add_argument("--registry", default="https://github.com/Peleke/brunnr", help="Skill registry URL")
     inst_p.add_argument("--with-tests", action="store_true", help="Also fetch test fixtures")
     inst_p.add_argument("--force", action="store_true", help="Overwrite existing skill")
     inst_p.add_argument("--list", action="store_true", dest="list_skills", help="List available skills")
-    inst_p.add_argument("-y", "--yes", action="store_true", help="Skip review prompt, install immediately")
+    inst_p.add_argument("-y", "--yes", action="store_true", help="Skip review prompt")
+    inst_p.add_argument(
+        "-t", "--target",
+        help="Install SKILL.md to this directory instead of ./skills/ (runtime use, skips schema/tests)",
+    )
 
     # --- brunnr eval ---
     eval_p = sub.add_parser("eval", help="Run eval harness for a skill")
@@ -45,24 +51,67 @@ def main() -> int:
     pipe_p.add_argument("--scan-only", action="store_true", help="Security scan only, skip evals")
     pipe_p.add_argument("--verbose", action="store_true")
 
+    # --- brunnr list ---
+    list_p = sub.add_parser("list", help="List installed skills")
+    list_p.add_argument("--json", action="store_true", dest="json_out", help="JSON output")
+
+    # --- brunnr search ---
+    search_p = sub.add_parser("search", help="Search the registry for skills")
+    search_p.add_argument("query", nargs="?", default="", help="Search query")
+    search_p.add_argument("--tag", help="Filter by tag")
+    search_p.add_argument("--json", action="store_true", dest="json_out", help="JSON output")
+
+    # --- brunnr inspect ---
+    insp_p = sub.add_parser("inspect", help="Preview a skill without installing")
+    insp_p.add_argument("skill", help="Skill slug to inspect")
+    insp_p.add_argument("--full", action="store_true", help="Show entire SKILL.md")
+    insp_p.add_argument("--json", action="store_true", dest="json_out", help="JSON output")
+
+    # --- brunnr update ---
+    upd_p = sub.add_parser("update", help="Update installed skills to latest")
+    upd_p.add_argument("skill", nargs="?", help="Specific skill to update (default: all)")
+    upd_p.add_argument("--dry-run", action="store_true", help="Show what would change")
+    upd_p.add_argument("--force", action="store_true", help="Skip prompts")
+
+    # --- brunnr explore ---
+    exp_p = sub.add_parser("explore", help="Browse skills from the registry")
+    exp_p.add_argument("--limit", type=int, default=20, help="Max skills to show")
+    exp_p.add_argument("--json", action="store_true", dest="json_out", help="JSON output")
+
+    # --- brunnr publish ---
+    pub_p = sub.add_parser("publish", help="Publish a skill to the registry (PR-based)")
+    pub_p.add_argument("path", help="Skill directory or SKILL.md path")
+    pub_p.add_argument("--dry-run", action="store_true", help="Validate + scan only")
+
+    # --- brunnr sync ---
+    sync_p = sub.add_parser("sync", help="Discover and publish local skills")
+    sync_p.add_argument("--dry-run", action="store_true", help="Show what would be published")
+
     args = parser.parse_args()
 
     if not args.command:
         parser.print_help()
         return 0
 
-    if args.command == "scan":
-        from brunnr.commands.scan import run
-        return run(args)
-    elif args.command == "install":
-        from brunnr.commands.install import run
-        return run(args)
-    elif args.command == "eval":
-        from brunnr.commands.eval import run
-        return run(args)
-    elif args.command == "pipeline":
-        from brunnr.commands.pipeline import run
-        return run(args)
+    dispatch = {
+        "scan": "brunnr.commands.scan",
+        "install": "brunnr.commands.install",
+        "eval": "brunnr.commands.eval",
+        "pipeline": "brunnr.commands.pipeline",
+        "list": "brunnr.commands.list_cmd",
+        "search": "brunnr.commands.search",
+        "inspect": "brunnr.commands.inspect_cmd",
+        "update": "brunnr.commands.update",
+        "explore": "brunnr.commands.explore",
+        "publish": "brunnr.commands.publish",
+        "sync": "brunnr.commands.sync_cmd",
+    }
+
+    module_name = dispatch.get(args.command)
+    if module_name:
+        import importlib
+        mod = importlib.import_module(module_name)
+        return mod.run(args)
 
     return 0
 

--- a/brunnr/commands/explore.py
+++ b/brunnr/commands/explore.py
@@ -1,0 +1,39 @@
+"""brunnr explore — browse skills from the registry."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from brunnr.registry import registry_base, list_skills, fetch_skill_metadata
+
+
+def run(args) -> int:
+    base = registry_base(args.registry)
+    limit = getattr(args, "limit", 20)
+    json_out = getattr(args, "json_out", False)
+
+    all_slugs = list_skills(base)
+    if not all_slugs:
+        print("No skills found (or registry unreachable).", file=sys.stderr)
+        return 1
+
+    results = []
+    for slug in all_slugs[:limit]:
+        meta = fetch_skill_metadata(base, slug)
+        desc = meta.get("description", "—") if meta else "—"
+        results.append({"slug": slug, "description": desc})
+
+    if json_out:
+        print(json.dumps({"skills": results}, indent=2))
+        return 0
+
+    print(f"Skills in registry ({len(all_slugs)} total):\n")
+    for r in results:
+        desc = r["description"][:70] + "…" if len(r["description"]) > 70 else r["description"]
+        print(f"  {r['slug']:<20} {desc}")
+
+    if len(all_slugs) > limit:
+        print(f"\n  ... and {len(all_slugs) - limit} more (use --limit to see more)")
+    print(f"\nRun `brunnr inspect <slug>` for details.")
+    return 0

--- a/brunnr/commands/inspect_cmd.py
+++ b/brunnr/commands/inspect_cmd.py
@@ -1,0 +1,62 @@
+"""brunnr inspect — preview a skill without installing."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from brunnr.registry import registry_base, fetch_skill_content, fetch_skill_metadata, repo_parts
+from brunnr.scanner import scan_skill_md
+
+
+def run(args) -> int:
+    base = registry_base(args.registry)
+    slug = args.skill
+    full = getattr(args, "full", False)
+    json_out = getattr(args, "json_out", False)
+
+    print(f"Fetching {slug}...")
+    content = fetch_skill_content(base, slug)
+    if content is None:
+        print(f"ERROR: skill '{slug}' not found in registry.", file=sys.stderr)
+        return 1
+
+    meta = fetch_skill_metadata(base, slug)
+    if meta is None:
+        meta = {"name": slug}
+
+    # Run scanner
+    scan = scan_skill_md(content)
+    scan_verdict = scan.get("verdict", "UNKNOWN")
+
+    if json_out:
+        print(json.dumps({
+            "slug": slug,
+            "metadata": meta,
+            "scan_result": scan_verdict,
+            "lines": len(content.splitlines()),
+        }, indent=2))
+        return 0
+
+    # Header
+    rp = repo_parts(base)
+    source_url = f"https://github.com/{rp[0]}/{rp[1]}/tree/main/skills/{slug}" if len(rp) >= 2 else "unknown"
+    print(f"\n{'=' * 60}")
+    print(f"  {meta.get('name', slug)}")
+    print(f"{'=' * 60}")
+    print(f"  Description: {meta.get('description', '—')}")
+    print(f"  Source:      {source_url}")
+    print(f"  Scan:        {scan_verdict}")
+    print(f"  Lines:       {len(content.splitlines())}")
+    print(f"{'=' * 60}\n")
+
+    if full:
+        print(content)
+    else:
+        lines = content.splitlines()
+        preview = "\n".join(lines[:30])
+        print(preview)
+        if len(lines) > 30:
+            print(f"\n  ... ({len(lines) - 30} more lines, use --full to see all)")
+
+    return 0

--- a/brunnr/commands/install.py
+++ b/brunnr/commands/install.py
@@ -5,52 +5,17 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from urllib.request import urlopen, Request
-from urllib.error import URLError
 
-_GITHUB_RAW = "https://raw.githubusercontent.com"
-
-
-def _fetch(url: str) -> str | None:
-    """Fetch a URL and return text content, or None on failure."""
-    try:
-        req = Request(url, headers={"User-Agent": "brunnr-cli"})
-        with urlopen(req, timeout=15) as resp:
-            return resp.read().decode("utf-8")
-    except (URLError, OSError):
-        return None
-
-
-def _registry_base(registry: str) -> str:
-    """Convert a GitHub repo URL to raw content base URL."""
-    # https://github.com/Peleke/brunnr -> https://raw.githubusercontent.com/Peleke/brunnr/main
-    if "github.com" in registry:
-        parts = registry.rstrip("/").replace("https://github.com/", "").split("/")
-        if len(parts) >= 2:
-            return f"{_GITHUB_RAW}/{parts[0]}/{parts[1]}/main"
-    return registry.rstrip("/")
-
-
-def _list_skills(base: str) -> list[str]:
-    """List available skills from registry (via GitHub API)."""
-    # Convert raw URL back to API URL
-    # https://raw.githubusercontent.com/Peleke/brunnr/main -> https://api.github.com/repos/Peleke/brunnr/contents/skills
-    parts = base.replace(f"{_GITHUB_RAW}/", "").split("/")
-    if len(parts) >= 3:
-        api_url = f"https://api.github.com/repos/{parts[0]}/{parts[1]}/contents/skills"
-        content = _fetch(api_url)
-        if content:
-            entries = json.loads(content)
-            return [e["name"] for e in entries if e["type"] == "dir"]
-    return []
+from brunnr.registry import fetch, registry_base, list_skills, repo_parts
+from brunnr.lockfile import add_skill
 
 
 def run(args) -> int:
-    base = _registry_base(args.registry)
+    base = registry_base(args.registry)
 
     # List mode
     if getattr(args, "list_skills", False):
-        skills = _list_skills(base)
+        skills = list_skills(base)
         if not skills:
             print("No skills found (or registry unreachable).", file=sys.stderr)
             return 1
@@ -64,8 +29,14 @@ def run(args) -> int:
         print("ERROR: skill name required. Use `brunnr install --list` to see available skills.", file=sys.stderr)
         return 1
 
-    dest = Path("skills") / slug
-    skill_file = dest / "SKILL.md"
+    # When --target is set, install SKILL.md only (runtime use, not repo structure)
+    target = getattr(args, "target", None)
+    if target:
+        dest = Path(target).expanduser() / slug
+        skill_file = dest / "SKILL.md"
+    else:
+        dest = Path("skills") / slug
+        skill_file = dest / "SKILL.md"
 
     if skill_file.exists() and not getattr(args, "force", False):
         print(f"Skill '{slug}' already installed at {skill_file}", file=sys.stderr)
@@ -75,7 +46,7 @@ def run(args) -> int:
     # Fetch SKILL.md
     skill_url = f"{base}/skills/{slug}/SKILL.md"
     print(f"Fetching {slug} from {args.registry}...")
-    content = _fetch(skill_url)
+    content = fetch(skill_url)
     if not content:
         print(f"ERROR: Could not fetch {skill_url}", file=sys.stderr)
         return 1
@@ -89,13 +60,12 @@ def run(args) -> int:
         print(preview)
         if len(lines) > 30:
             print(f"  ... ({len(lines) - 30} more lines)")
-        print(f"---")
-        # Show GitHub link for full review
-        repo_parts = base.replace(f"{_GITHUB_RAW}/", "").split("/")
-        if len(repo_parts) >= 2:
-            print(f"\nFull source: https://github.com/{repo_parts[0]}/{repo_parts[1]}/tree/main/skills/{slug}")
+        print("---")
+        rp = repo_parts(base)
+        if len(rp) >= 2:
+            print(f"\nFull source: https://github.com/{rp[0]}/{rp[1]}/tree/main/skills/{slug}")
         try:
-            answer = input(f"\nInstall {slug} to ./skills/{slug}/? [y/N] ").strip().lower()
+            answer = input(f"\nInstall {slug} to {dest}/? [y/N] ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             print("\nAborted.", file=sys.stderr)
             return 1
@@ -107,9 +77,14 @@ def run(args) -> int:
     skill_file.write_text(content)
     print(f"  -> {skill_file} ({len(content.splitlines())} lines)")
 
+    # When --target is set, skip schema/test/lockfile (runtime-only install)
+    if target:
+        print(f"\nInstalled {slug} to {dest}/")
+        return 0
+
     # Fetch schema (optional)
     schema_url = f"{base}/schemas/{slug}/output.schema.json"
-    schema_content = _fetch(schema_url)
+    schema_content = fetch(schema_url)
     if schema_content:
         schema_dest = Path("schemas") / slug
         schema_dest.mkdir(parents=True, exist_ok=True)
@@ -119,7 +94,7 @@ def run(args) -> int:
     # Fetch test fixtures (optional)
     if getattr(args, "with_tests", False):
         spec_url = f"{base}/tests/{slug}/test-spec.json"
-        spec_content = _fetch(spec_url)
+        spec_content = fetch(spec_url)
         if spec_content:
             test_dest = Path("tests") / slug
             test_dest.mkdir(parents=True, exist_ok=True)
@@ -141,11 +116,17 @@ def run(args) -> int:
                     print(f"  WARNING: fixture escapes test dir: {fixture_rel}", file=sys.stderr)
                     continue
                 fixture_url = f"{base}/tests/{slug}/{fixture_rel}"
-                fixture_content = _fetch(fixture_url)
+                fixture_content = fetch(fixture_url)
                 if fixture_content:
                     fixture_path.parent.mkdir(parents=True, exist_ok=True)
                     fixture_path.write_text(fixture_content)
                     print(f"  -> tests/{slug}/{fixture_rel}")
+
+    # Update lockfile
+    installed_files = [f"skills/{slug}/SKILL.md"]
+    if schema_content:
+        installed_files.append(f"schemas/{slug}/output.schema.json")
+    add_skill(".", slug, content, args.registry, files=installed_files)
 
     print(f"\nInstalled {slug} to ./{dest}/")
     print(f"\nTip: Run `brunnr eval {slug} --dry-run` to validate locally.")

--- a/brunnr/commands/list_cmd.py
+++ b/brunnr/commands/list_cmd.py
@@ -1,0 +1,49 @@
+"""brunnr list — show installed skills."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from brunnr.lockfile import read_lockfile
+
+
+def run(args) -> int:
+    workdir = getattr(args, "workdir", ".")
+    json_out = getattr(args, "json_out", False)
+
+    lockdata = read_lockfile(workdir)
+    skills = lockdata.get("skills", {})
+
+    # Fallback: scan filesystem if lockfile is empty
+    if not skills:
+        skills_dir = Path(workdir) / "skills"
+        if skills_dir.is_dir():
+            for d in sorted(skills_dir.iterdir()):
+                if d.is_dir() and (d / "SKILL.md").exists():
+                    skills[d.name] = {
+                        "installed_at": "unknown",
+                        "source_hash": "—",
+                        "scan_result": "unknown",
+                    }
+
+    if not skills:
+        print("No skills installed.", file=sys.stderr)
+        return 0
+
+    if json_out:
+        print(json.dumps({"skills": skills}, indent=2))
+        return 0
+
+    print(f"Installed skills ({Path(workdir).resolve() / 'skills'}):\n")
+    for slug, meta in sorted(skills.items()):
+        status = meta.get("scan_result", "unknown")
+        date = meta.get("installed_at", "unknown")[:10]
+        hash_prefix = meta.get("source_hash", "—")
+        if hash_prefix.startswith("sha256:"):
+            hash_prefix = hash_prefix[:15] + "…"
+        print(f"  {slug:<20} {status:<10} {date:<12} {hash_prefix}")
+
+    print(f"\n{len(skills)} skill(s) installed")
+    return 0

--- a/brunnr/commands/publish.py
+++ b/brunnr/commands/publish.py
@@ -1,0 +1,122 @@
+"""brunnr publish — publish a skill to the registry via PR."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from brunnr.frontmatter import parse_frontmatter
+from brunnr.scanner import scan_skill_md
+
+
+def run(args) -> int:
+    skill_path = Path(args.path).expanduser().resolve()
+    dry_run = getattr(args, "dry_run", False)
+
+    # Validate skill directory
+    if skill_path.is_file() and skill_path.name == "SKILL.md":
+        skill_dir = skill_path.parent
+        skill_file = skill_path
+    elif skill_path.is_dir():
+        skill_dir = skill_path
+        skill_file = skill_path / "SKILL.md"
+    else:
+        print(f"ERROR: {skill_path} is not a skill directory or SKILL.md file.", file=sys.stderr)
+        return 1
+
+    if not skill_file.exists():
+        print(f"ERROR: {skill_file} not found.", file=sys.stderr)
+        return 1
+
+    content = skill_file.read_text()
+    fm = parse_frontmatter(content)
+    slug = fm.get("name", skill_dir.name)
+
+    print(f"Publishing {slug}...")
+
+    # Step 1: scan
+    print("  Running security scan...")
+    scan = scan_skill_md(content)
+    verdict = scan.get("verdict", "UNKNOWN")
+    print(f"  Scan: {verdict}")
+
+    if verdict == "BLOCK":
+        print("ERROR: skill blocked by scanner. Fix findings before publishing.", file=sys.stderr)
+        return 1
+    if verdict == "FLAG":
+        print("WARNING: skill has flagged findings. Proceeding with caution.", file=sys.stderr)
+
+    if dry_run:
+        print(f"\n  [dry-run] Would publish {slug} (scan: {verdict})")
+        print(f"  [dry-run] SKILL.md: {len(content.splitlines())} lines")
+        return 0
+
+    # Step 2: fork + branch + push + PR via gh CLI
+    registry = "Peleke/brunnr"
+    branch = f"skill/{slug}"
+
+    print(f"  Creating PR to {registry}...")
+    try:
+        # Fork (idempotent)
+        subprocess.run(
+            ["gh", "repo", "fork", registry, "--clone=false"],
+            check=False, capture_output=True,
+        )
+
+        # Clone to temp, create branch, copy skill, push, PR
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp) / "brunnr"
+            subprocess.run(
+                ["gh", "repo", "clone", registry, str(tmp_path)],
+                check=True, capture_output=True,
+            )
+
+            # Create branch
+            subprocess.run(
+                ["git", "checkout", "-b", branch],
+                cwd=tmp_path, check=True, capture_output=True,
+            )
+
+            # Copy skill files
+            dest = tmp_path / "skills" / slug
+            dest.mkdir(parents=True, exist_ok=True)
+            (dest / "SKILL.md").write_text(content)
+
+            # Copy other files if they exist
+            for extra in skill_dir.iterdir():
+                if extra.name != "SKILL.md" and extra.is_file():
+                    (dest / extra.name).write_text(extra.read_text())
+
+            # Commit and push
+            subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "commit", "-m", f"feat: add {slug} skill"],
+                cwd=tmp_path, check=True, capture_output=True,
+            )
+            subprocess.run(
+                ["git", "push", "-u", "origin", branch],
+                cwd=tmp_path, check=True, capture_output=True,
+            )
+
+            # Create PR
+            result = subprocess.run(
+                ["gh", "pr", "create",
+                 "--repo", registry,
+                 "--title", f"feat: add {slug} skill",
+                 "--body", f"Skill `{slug}` published via `brunnr publish`.\n\nScan result: **{verdict}**"],
+                cwd=tmp_path, check=True, capture_output=True, text=True,
+            )
+            pr_url = result.stdout.strip()
+            print(f"  PR created: {pr_url}")
+
+    except FileNotFoundError:
+        print("ERROR: `gh` CLI not found. Install: https://cli.github.com/", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: git/gh command failed: {e.stderr}", file=sys.stderr)
+        return 1
+
+    print(f"\nPublished {slug}!")
+    return 0

--- a/brunnr/commands/search.py
+++ b/brunnr/commands/search.py
@@ -1,0 +1,59 @@
+"""brunnr search — find skills in the registry."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from brunnr.registry import fetch, registry_base, list_skills, fetch_skill_metadata
+
+
+def run(args) -> int:
+    base = registry_base(args.registry)
+    query = getattr(args, "query", "")
+    tag_filter = getattr(args, "tag", None)
+    json_out = getattr(args, "json_out", False)
+
+    if not query and not tag_filter:
+        print("ERROR: provide a search query or --tag filter.", file=sys.stderr)
+        return 1
+
+    # Get all skills from registry, then filter locally
+    all_slugs = list_skills(base)
+    if not all_slugs:
+        print("No skills found (or registry unreachable).", file=sys.stderr)
+        return 1
+
+    results = []
+    for slug in all_slugs:
+        meta = fetch_skill_metadata(base, slug)
+        if meta is None:
+            continue
+
+        name = meta.get("name", slug)
+        desc = meta.get("description", "")
+
+        # Query match: slug or description
+        if query and query.lower() not in name.lower() and query.lower() not in desc.lower():
+            continue
+
+        # Tag filter (check if tag appears in description as fallback — SKILL.md frontmatter is flat)
+        if tag_filter and tag_filter.lower() not in desc.lower() and tag_filter.lower() not in name.lower():
+            continue
+
+        results.append({"slug": slug, "description": desc})
+
+    if not results:
+        print(f"No skills matching '{query or tag_filter}'.", file=sys.stderr)
+        return 1
+
+    if json_out:
+        print(json.dumps({"results": results}, indent=2))
+        return 0
+
+    print(f"Skills matching '{query or tag_filter}':\n")
+    for r in results:
+        desc = r["description"][:80] + "…" if len(r["description"]) > 80 else r["description"]
+        print(f"  {r['slug']:<20} {desc}")
+    print(f"\n{len(results)} result(s)")
+    return 0

--- a/brunnr/commands/sync_cmd.py
+++ b/brunnr/commands/sync_cmd.py
@@ -1,0 +1,94 @@
+"""brunnr sync — discover local skills and publish new/updated ones."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from brunnr.registry import registry_base, list_skills, fetch_skill_content
+from brunnr.lockfile import content_hash
+from brunnr.discovery import discover_skill_files
+from brunnr.frontmatter import parse_frontmatter
+
+
+def run(args) -> int:
+    base = registry_base(args.registry)
+    dry_run = getattr(args, "dry_run", False)
+
+    # Discover local skills
+    local_files = discover_skill_files()
+    if not local_files:
+        print("No local skills found in ./skills/", file=sys.stderr)
+        return 0
+
+    local_slugs = {}
+    for f in local_files:
+        slug = f.parent.name
+        local_slugs[slug] = f
+
+    # Get registry skills
+    print("Checking registry...")
+    remote_slugs = set(list_skills(base))
+
+    new_skills = []
+    updated_skills = []
+
+    for slug, skill_file in sorted(local_slugs.items()):
+        content = skill_file.read_text()
+        local_hash = content_hash(content)
+
+        if slug not in remote_slugs:
+            new_skills.append(slug)
+            continue
+
+        # Check if updated
+        remote_content = fetch_skill_content(base, slug)
+        if remote_content is None:
+            new_skills.append(slug)
+            continue
+
+        remote_hash = content_hash(remote_content)
+        if local_hash != remote_hash:
+            updated_skills.append(slug)
+
+    if not new_skills and not updated_skills:
+        print("All local skills are in sync with the registry.")
+        return 0
+
+    if new_skills:
+        print(f"\nNew skills (not in registry):")
+        for s in new_skills:
+            print(f"  + {s}")
+
+    if updated_skills:
+        print(f"\nUpdated skills (local differs from registry):")
+        for s in updated_skills:
+            print(f"  ~ {s}")
+
+    if dry_run:
+        total = len(new_skills) + len(updated_skills)
+        print(f"\n{total} skill(s) would be published. Use without --dry-run to publish.")
+        return 0
+
+    # Publish each via the publish command
+    from argparse import Namespace
+    from brunnr.commands.publish import run as publish_run
+
+    failed = []
+    for slug in new_skills + updated_skills:
+        skill_path = local_slugs[slug].parent
+        pub_args = Namespace(
+            path=str(skill_path),
+            dry_run=False,
+        )
+        print(f"\n--- Publishing {slug} ---")
+        rc = publish_run(pub_args)
+        if rc != 0:
+            failed.append(slug)
+
+    if failed:
+        print(f"\nFailed to publish: {', '.join(failed)}", file=sys.stderr)
+        return 1
+
+    print(f"\nSync complete. {len(new_skills) + len(updated_skills)} skill(s) published.")
+    return 0

--- a/brunnr/commands/update.py
+++ b/brunnr/commands/update.py
@@ -1,0 +1,86 @@
+"""brunnr update — update installed skills to latest."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from brunnr.registry import fetch, registry_base, fetch_skill_content
+from brunnr.lockfile import read_lockfile, add_skill, content_hash
+from brunnr.scanner import scan_skill_md
+
+
+def run(args) -> int:
+    base = registry_base(args.registry)
+    target_slug = getattr(args, "skill", None)
+    dry_run = getattr(args, "dry_run", False)
+    force = getattr(args, "force", False)
+
+    lockdata = read_lockfile(".")
+    skills = lockdata.get("skills", {})
+
+    if not skills:
+        print("No skills in lockfile. Run `brunnr list` to check.", file=sys.stderr)
+        return 0
+
+    slugs = [target_slug] if target_slug else sorted(skills.keys())
+    updated = 0
+
+    for slug in slugs:
+        local_meta = skills.get(slug)
+        if not local_meta:
+            print(f"  {slug}: not installed, skipping", file=sys.stderr)
+            continue
+
+        local_hash = local_meta.get("source_hash", "")
+
+        # Fetch latest from registry
+        content = fetch_skill_content(base, slug)
+        if content is None:
+            print(f"  {slug}: not found in registry, skipping")
+            continue
+
+        remote_hash = content_hash(content)
+
+        if local_hash == remote_hash:
+            print(f"  {slug}: up to date")
+            continue
+
+        # Run scanner on new content
+        scan = scan_skill_md(content)
+        verdict = scan.get("verdict", "UNKNOWN")
+        if verdict == "BLOCK":
+            print(f"  {slug}: BLOCKED by scanner — skipping update", file=sys.stderr)
+            continue
+
+        if dry_run:
+            print(f"  {slug}: update available ({local_hash[:15]}… → {remote_hash[:15]}…) [scan: {verdict}]")
+            updated += 1
+            continue
+
+        # Prompt unless --force
+        if not force and sys.stdin.isatty():
+            try:
+                answer = input(f"  Update {slug}? (scan: {verdict}) [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print("\nAborted.", file=sys.stderr)
+                return 1
+            if answer not in ("y", "yes"):
+                print(f"  {slug}: skipped")
+                continue
+
+        # Write updated SKILL.md
+        skill_file = Path("skills") / slug / "SKILL.md"
+        skill_file.parent.mkdir(parents=True, exist_ok=True)
+        skill_file.write_text(content)
+
+        # Update lockfile
+        registry = local_meta.get("registry", "https://github.com/Peleke/brunnr")
+        add_skill(".", slug, content, registry, scan_result=verdict.lower())
+
+        print(f"  {slug}: updated ({verdict})")
+        updated += 1
+
+    action = "would update" if dry_run else "updated"
+    print(f"\n{updated} skill(s) {action}")
+    return 0

--- a/brunnr/frontmatter.py
+++ b/brunnr/frontmatter.py
@@ -1,0 +1,35 @@
+"""Shared frontmatter parsing for SKILL.md files."""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    """Extract YAML frontmatter from a SKILL.md file.
+
+    Returns a flat dict of key-value pairs. Values are stripped of quotes.
+    """
+    if not text.startswith("---"):
+        return {}
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    fm = {}
+    for line in parts[1].strip().splitlines():
+        if ":" in line:
+            key, val = line.split(":", 1)
+            fm[key.strip()] = val.strip().strip('"').strip("'")
+    return fm
+
+
+def extract_body(content: str) -> str:
+    """Extract body text after frontmatter."""
+    match = re.match(r"^---\s*\n.*?\n---\s*\n?(.*)", content, re.DOTALL)
+    return match.group(1) if match else content
+
+
+def extract_description(content: str) -> str:
+    """Extract description from frontmatter."""
+    match = re.search(r"^description:\s*[\"']?(.+?)[\"']?\s*$", content, re.MULTILINE)
+    return match.group(1) if match else ""

--- a/brunnr/lockfile.py
+++ b/brunnr/lockfile.py
@@ -1,0 +1,63 @@
+"""Lockfile management for installed brunnr skills."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOCKFILE_NAME = "skills.lock.json"
+
+
+def _lockfile_path(workdir: str | Path = ".") -> Path:
+    return Path(workdir) / LOCKFILE_NAME
+
+
+def read_lockfile(workdir: str | Path = ".") -> dict:
+    """Read the lockfile. Returns empty structure if missing."""
+    path = _lockfile_path(workdir)
+    if not path.exists():
+        return {"version": 1, "skills": {}}
+    return json.loads(path.read_text())
+
+
+def write_lockfile(workdir: str | Path, data: dict) -> None:
+    """Write the lockfile."""
+    path = _lockfile_path(workdir)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def add_skill(
+    workdir: str | Path,
+    slug: str,
+    content: str,
+    registry: str,
+    scan_result: str = "unknown",
+    files: list[str] | None = None,
+) -> None:
+    """Add or update a skill entry in the lockfile."""
+    data = read_lockfile(workdir)
+    data["skills"][slug] = {
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+        "source_hash": "sha256:" + hashlib.sha256(content.encode()).hexdigest()[:16],
+        "registry": registry,
+        "scan_result": scan_result,
+        "files": files or [f"skills/{slug}/SKILL.md"],
+    }
+    write_lockfile(workdir, data)
+
+
+def remove_skill(workdir: str | Path, slug: str) -> bool:
+    """Remove a skill from the lockfile. Returns True if it existed."""
+    data = read_lockfile(workdir)
+    if slug in data["skills"]:
+        del data["skills"][slug]
+        write_lockfile(workdir, data)
+        return True
+    return False
+
+
+def content_hash(content: str) -> str:
+    """Compute the sha256 hash prefix used in lockfile entries."""
+    return "sha256:" + hashlib.sha256(content.encode()).hexdigest()[:16]

--- a/brunnr/registry.py
+++ b/brunnr/registry.py
@@ -1,0 +1,64 @@
+"""Centralized registry interaction for brunnr CLI."""
+
+from __future__ import annotations
+
+import json
+from urllib.request import urlopen, Request
+from urllib.error import URLError
+
+from brunnr.frontmatter import parse_frontmatter
+
+_GITHUB_RAW = "https://raw.githubusercontent.com"
+
+
+def fetch(url: str) -> str | None:
+    """Fetch a URL and return text content, or None on failure."""
+    try:
+        req = Request(url, headers={"User-Agent": "brunnr-cli"})
+        with urlopen(req, timeout=15) as resp:
+            return resp.read().decode("utf-8")
+    except (URLError, OSError):
+        return None
+
+
+def registry_base(registry: str) -> str:
+    """Convert a GitHub repo URL to raw content base URL."""
+    if "github.com" in registry:
+        parts = registry.rstrip("/").replace("https://github.com/", "").split("/")
+        if len(parts) >= 2:
+            return f"{_GITHUB_RAW}/{parts[0]}/{parts[1]}/main"
+    return registry.rstrip("/")
+
+
+def list_skills(base: str) -> list[str]:
+    """List available skills from registry (via GitHub API)."""
+    parts = base.replace(f"{_GITHUB_RAW}/", "").split("/")
+    if len(parts) >= 3:
+        api_url = f"https://api.github.com/repos/{parts[0]}/{parts[1]}/contents/skills"
+        content = fetch(api_url)
+        if content:
+            entries = json.loads(content)
+            return [e["name"] for e in entries if e["type"] == "dir"]
+    return []
+
+
+def fetch_skill_content(base: str, slug: str) -> str | None:
+    """Fetch SKILL.md content for a skill from the registry."""
+    url = f"{base}/skills/{slug}/SKILL.md"
+    return fetch(url)
+
+
+def fetch_skill_metadata(base: str, slug: str) -> dict[str, str] | None:
+    """Fetch and parse frontmatter metadata for a skill."""
+    content = fetch_skill_content(base, slug)
+    if content is None:
+        return None
+    fm = parse_frontmatter(content)
+    if not fm:
+        fm = {"name": slug}
+    return fm
+
+
+def repo_parts(base: str) -> list[str]:
+    """Extract [owner, repo] from a raw base URL."""
+    return base.replace(f"{_GITHUB_RAW}/", "").split("/")[:2]

--- a/brunnr/scanner.py
+++ b/brunnr/scanner.py
@@ -296,16 +296,8 @@ def scan_skill_md(content: str) -> ScanResult:
     return result
 
 
-def _extract_body(content: str) -> str:
-    """Extract body text after frontmatter."""
-    match = re.match(r"^---\s*\n.*?\n---\s*\n?(.*)", content, re.DOTALL)
-    return match.group(1) if match else content
-
-
-def _extract_description(content: str) -> str:
-    """Extract description from frontmatter."""
-    match = re.search(r"^description:\s*[\"']?(.+?)[\"']?\s*$", content, re.MULTILINE)
-    return match.group(1) if match else ""
+from brunnr.frontmatter import extract_body as _extract_body  # noqa: E302
+from brunnr.frontmatter import extract_description as _extract_description
 
 
 def _has_security_context(content: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,8 +37,8 @@ class TestCLI:
     def test_install_help(self):
         r = _run(["install", "--help"])
         assert r.returncode == 0
-        assert "--registry" in r.stdout
         assert "--yes" in r.stdout
+        assert "--target" in r.stdout
 
     def test_eval_help(self):
         r = _run(["eval", "--help"])


### PR DESCRIPTION
## Summary
Implements issue #11 — brings brunnr CLI to parity with ClawHub.

### Infrastructure
- `brunnr/frontmatter.py`, `brunnr/registry.py`, `brunnr/lockfile.py` extracted from existing modules

### Install improvements
- `--target/-t` flag for runtime-only installs (SKILL.md only, no schema/tests)
- Lockfile tracking on install

### New commands
`list`, `search`, `inspect`, `update`, `explore`, `publish`, `sync`

## Test plan
- [x] All 78 existing tests pass

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)