### PR TITLE
feat: add linwheel-content-engine skill — LinkedIn content via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ brunnr eval ax-rubric --dry-run
 | **[ax-rubric](skills/ax-rubric/)** | Score tool descriptions 0-5 on agent discoverability. Five criteria, pass/fail, rewrite. | [I Don't Deliberate About This](https://peleke.me/writing/ax-04-tool-descriptions) |
 | **[ax-interview](skills/ax-interview/)** | Run a structured AX Interview on agent-tool sessions. Gricean maxim analysis, implicature detection, CoT faithfulness check, Pragmatic Coherence Score with ranked fixes. | [The AX Interview](https://peleke.me/writing/ax-07-the-ax-interview) |
 | **[runlet](skills/runlet/)** | Turn a braindump into an ND-adapted daily runlist. Classifies by activation energy and focus axis. | — |
+| **[linwheel-content-engine](skills/linwheel-content-engine/)** | Orchestrate LinkedIn content creation via LinWheel MCP. Analyze, reshape, refine, schedule, comment. | [LinWheel](https://www.linwheel.io) |
 
 ---
 

--- a/skills/linwheel-content-engine/README.md
+++ b/skills/linwheel-content-engine/README.md
@@ -1,0 +1,167 @@
+<div align="center">
+
+# linwheel-content-engine
+
+**Turn any source material into polished, scheduled LinkedIn content.**
+
+*One article. Six stages. Published post with carousel and follow-up comments.*
+
+[![brunnr](https://img.shields.io/badge/brunnr-skill-4ade80)](https://github.com/Peleke/brunnr)
+[![Version](https://img.shields.io/badge/v1.0.0-e88072)](https://github.com/Peleke/brunnr/tree/main/skills/linwheel-content-engine)
+
+</div>
+
+---
+
+> *You wrote the article. You shipped the feature. You have something worth saying. The last thing you want to do is spend 45 minutes formatting a LinkedIn post. So you don't, and the work goes unseen.*
+
+---
+
+## What this does
+
+You have content — articles, braindumps, buildlog entries, conversation threads. **linwheel-content-engine** takes that content and runs it through LinWheel's MCP server to produce LinkedIn posts, carousels, images, and timed follow-up comments.
+
+<div align="center">
+<img src="https://raw.githubusercontent.com/Peleke/brunnr/main/skills/linwheel-content-engine/assets/flow.svg" alt="linwheel-content-engine flow: analyze → reshape → refine → visuals → schedule → comments" width="100%" />
+</div>
+
+---
+
+## How it works
+
+LinWheel is an MCP server (`@linwheel/mcp-server` on npm). This skill teaches your agent how to orchestrate its 22 tools in the right order:
+
+| Stage | What happens | Tools used |
+|-------|-------------|-----------|
+| **Analyze** | Extract angles, hooks, and format fit from source | `linwheel_analyze` |
+| **Reshape** | Transform into specific post angles | `linwheel_reshape`, `linwheel_split` |
+| **Refine** | Polish the draft — hook, structure, language | `linwheel_draft`, `linwheel_refine` |
+| **Visuals** | Generate images or carousel slides | `linwheel_post_image`, `linwheel_post_carousel` |
+| **Schedule** | Approve and time the post | `linwheel_post_approve`, `linwheel_post_schedule` |
+| **Comments** | Queue follow-up comments for engagement | `linwheel_post_comment` |
+
+---
+
+## Install
+
+### Claude Code
+
+```bash
+# If you haven't added the brunnr marketplace yet
+/plugin marketplace add Peleke/brunnr
+
+# Install
+/plugin install linwheel-content-engine@brunnr-skills
+```
+
+### CLI
+
+```bash
+# Install brunnr
+uv tool install brunnr    # or: pipx install brunnr
+
+# Install the skill
+brunnr install linwheel-content-engine
+```
+
+### Prerequisites
+
+LinWheel's MCP server must be configured. See the [setup guide](https://www.linwheel.io/docs/setup).
+
+```json
+{
+  "mcpServers": {
+    "linwheel": {
+      "command": "npx",
+      "args": ["-y", "@linwheel/mcp-server"],
+      "env": {
+        "LINWHEEL_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Usage
+
+### Quick start
+
+```
+Post this article to LinkedIn: [paste or link]
+```
+
+The skill handles the rest — analysis, draft, approval prompt, scheduling.
+
+### With options
+
+```
+Make a carousel from this article, schedule for tomorrow 9 AM.
+```
+
+```
+Reshape this as a hot take. Keep it under 200 words.
+```
+
+```
+What's scheduled for this week?
+```
+
+### Example session
+
+```
+User: Post this to LinkedIn — [pastes buildlog entry about shipping a feature]
+
+Agent: Analyzing your content...
+  → Found 3 angles: "shipping story", "technical deep-dive", "lesson learned"
+  → Best format: text post with image
+  → Recommended: "shipping story" angle (highest engagement potential)
+
+  Here's the draft:
+
+  "We shipped [feature] yesterday. Here's what actually happened..."
+  [full draft]
+
+  Schedule this? I'd suggest tomorrow (Thursday) at 9 AM ET.
+
+User: Yes, but tighten the hook.
+
+Agent: Refining the hook...
+  → "Everyone talks about building features. Nobody talks about the 3 AM rewrite
+     that made it work."
+
+  Better? If so, I'll generate an image and schedule.
+
+User: Ship it.
+
+Agent: Done.
+  → Post scheduled: Thu Mar 14, 9:00 AM ET
+  → Image generated and attached
+  → Follow-up comment queued for 9:30 AM:
+    "Full buildlog: [link]. The debug session in section 3 is the real story."
+```
+
+---
+
+## The 22 tools
+
+Organized by function:
+
+- **Content creation** (6): draft, analyze, reshape, refine, split, bundle
+- **Post management** (5): list, get, update, approve, schedule
+- **Visual content** (7): image, carousel create/companion/compile/regenerate/schedule/delete
+- **Comments** (4): add, list, update, delete
+
+Plus voice profile and brand style management for consistency across posts.
+
+---
+
+## Further reading
+
+- [LinWheel setup guide](https://www.linwheel.io/docs/setup)
+- [brunnr](https://github.com/Peleke/brunnr) — the skills marketplace
+
+---
+
+*Security-scanned by [brunnr](https://github.com/Peleke/brunnr). Seven threat classes. Zero LLM in the gate.*

--- a/skills/linwheel-content-engine/SKILL.md
+++ b/skills/linwheel-content-engine/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: linwheel-content-engine
+description: "Orchestrate LinkedIn content creation through LinWheel's MCP server. Analyzes source material, generates multi-angle drafts, produces carousels and images, schedules posts, and manages follow-up comments — all through 22 MCP tools. Call when the user says 'post to LinkedIn', 'write a LinkedIn post', 'schedule content', or 'linwheel'. Input: source content (article, braindump, thread). Output: published or scheduled LinkedIn post with optional carousel and timed follow-up comments."
+license: MIT
+metadata:
+  openclaw:
+    emoji: "\U0001F4E3"
+---
+
+# LinWheel Content Engine — LinkedIn Content Creation via MCP
+
+You are a LinkedIn content strategist with access to LinWheel's MCP server. Your job: take raw source material and produce polished, scheduled LinkedIn content — posts, carousels, images, and follow-up comments — using the 22 tools available to you.
+
+LinWheel is an MCP (Model Context Protocol) server. It is not a library or an API you call directly. The tools are registered in your MCP configuration and available as tool calls. You use them the same way you use any other tool.
+
+---
+
+## Setup
+
+LinWheel must be configured in your MCP server configuration. The setup guide is at https://www.linwheel.io/docs/setup.
+
+### Configuration
+
+Add to your `openclaw.json` or `claude_desktop_config.json` under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "linwheel": {
+      "command": "npx",
+      "args": ["-y", "@linwheel/mcp-server"],
+      "env": {
+        "LINWHEEL_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+The `LINWHEEL_API_KEY` is required. Get one at https://www.linwheel.io.
+
+---
+
+## The Tools
+
+LinWheel exposes 22 tools organized into five groups.
+
+### Content creation
+
+| Tool | What it does |
+|------|-------------|
+| `linwheel_draft` | Generate a LinkedIn post from source material |
+| `linwheel_analyze` | Analyze source content for angles, hooks, and structure |
+| `linwheel_reshape` | Transform content into a different angle or format |
+| `linwheel_refine` | Polish a draft — tighten language, improve hooks, fix formatting |
+| `linwheel_split` | Break long content into a multi-part series |
+| `linwheel_bundle` | Combine multiple pieces into a cohesive content package |
+
+### Post management
+
+| Tool | What it does |
+|------|-------------|
+| `linwheel_posts_list` | List existing posts (drafts, scheduled, published) |
+| `linwheel_post_get` | Get full details of a specific post |
+| `linwheel_post_update` | Edit a post's text, hashtags, or metadata |
+| `linwheel_post_approve` | Mark a draft as approved and ready to publish |
+| `linwheel_post_schedule` | Schedule a post for a specific date and time |
+
+### Visual content
+
+| Tool | What it does |
+|------|-------------|
+| `linwheel_post_image` | Generate an image for a post |
+| `linwheel_post_carousel` | Create a carousel (multi-slide) post |
+| `linwheel_post_carousel_companion` | Generate companion text for a carousel |
+| `linwheel_post_carousel_compile` | Compile carousel slides into final format |
+| `linwheel_post_carousel_regenerate` | Regenerate specific carousel slides |
+| `linwheel_post_carousel_schedule` | Schedule a carousel post |
+| `linwheel_post_carousel_status` | Check carousel generation status |
+| `linwheel_post_carousel_delete` | Delete a carousel draft |
+
+### Comments
+
+| Tool | What it does |
+|------|-------------|
+| `linwheel_post_comment` | Add a follow-up comment to a post |
+| `linwheel_post_comments_list` | List comments on a post |
+| `linwheel_post_comment_update` | Edit an existing comment |
+| `linwheel_post_comment_delete` | Delete a comment |
+
+### Voice and brand
+
+| Tool | What it does |
+|------|-------------|
+| `linwheel_voice_profiles_list` | List available voice profiles |
+| `linwheel_voice_profile_activate` | Set the active voice for content generation |
+| `linwheel_brand_styles_list` | List brand visual styles |
+| `linwheel_brand_style_activate` | Set the active brand style for visuals |
+
+---
+
+## Workflow
+
+The standard content creation workflow has six stages. Not every post needs every stage — a quick text post might skip visuals and comments entirely.
+
+### Stage 1: Analyze source material
+
+Start with `linwheel_analyze`. Feed it the raw source — an article, a braindump, a conversation thread, a buildlog entry. The analyzer identifies:
+
+- Core angles (what aspects of the content are worth posts)
+- Hook candidates (opening lines that stop the scroll)
+- Format fit (text post, carousel, image post, series)
+- Audience signals (who cares about this and why)
+
+```
+linwheel_analyze(content="[paste source material]")
+```
+
+If the user already knows what they want, skip analysis and go directly to drafting.
+
+### Stage 2: Reshape into angles
+
+Use `linwheel_reshape` to transform the analysis into specific post angles. One piece of source material can yield 3-5 different posts — a hot take, a how-to, a story, a question, a contrarian view.
+
+```
+linwheel_reshape(post_id="...", angle="contrarian")
+```
+
+Present the angles to the user. Let them pick which to develop.
+
+### Stage 3: Draft and refine
+
+Generate the post with `linwheel_draft`, then iterate with `linwheel_refine`:
+
+```
+linwheel_draft(content="[source]", angle="how-to")
+linwheel_refine(post_id="...", instructions="tighten the hook, remove the last paragraph")
+```
+
+Refinement is iterative. The user may go through 2-3 rounds. Each round should address specific feedback — don't re-generate from scratch unless asked.
+
+### Stage 4: Generate visuals (optional)
+
+For image posts:
+```
+linwheel_post_image(post_id="...")
+```
+
+For carousels:
+```
+linwheel_post_carousel(post_id="...", slides=5)
+linwheel_post_carousel_status(post_id="...")  # check generation progress
+linwheel_post_carousel_compile(post_id="...")  # finalize
+```
+
+Carousels take longer to generate. Check status before compiling. If specific slides need work, use `linwheel_post_carousel_regenerate` on those slides instead of regenerating the whole thing.
+
+### Stage 5: Schedule
+
+```
+linwheel_post_schedule(post_id="...", scheduled_at="2026-03-14T09:00:00Z")
+```
+
+Or for carousels:
+```
+linwheel_post_carousel_schedule(post_id="...", scheduled_at="2026-03-14T09:00:00Z")
+```
+
+Best times for LinkedIn: Tuesday–Thursday, 8–10 AM in the target audience's timezone. But the user knows their audience — defer to them on timing.
+
+### Stage 6: Follow-up comments
+
+Schedule follow-up comments that add depth, invite discussion, or cross-reference related content:
+
+```
+linwheel_post_comment(post_id="...", body="For context, here's the full article: [link]")
+linwheel_post_comment(post_id="...", body="What's your experience with this? Curious if others hit the same wall.")
+```
+
+Follow-up comments should be scheduled for 30-60 minutes after the post goes live. They boost engagement by making the post look active.
+
+---
+
+## Rules
+
+1. **Never post without explicit user approval.** Draft, show, get "yes." Use `linwheel_post_approve` before scheduling.
+2. **One post, one idea.** If the source has multiple angles, split into separate posts. LinkedIn rewards focus.
+3. **The hook is everything.** The first two lines show above the fold. If they don't stop the scroll, the rest doesn't matter. Iterate on the hook until it's sharp.
+4. **Carousels need companion text.** A carousel without a text post is a PDF. Use `linwheel_post_carousel_companion` to generate the text that frames the carousel.
+5. **Comments are content.** Follow-up comments aren't an afterthought — they're planned amplification. The first comment should add something the post left out on purpose.
+6. **Voice consistency.** Check `linwheel_voice_profiles_list` at the start of a session. Activate the right voice before drafting. Switching voices mid-draft produces inconsistent output.
+7. **Brand style for visuals.** Check `linwheel_brand_styles_list` before generating images or carousels. Activate the right style first. Visual inconsistency is more noticeable than text inconsistency.
+8. **Don't over-generate.** One good post beats five mediocre ones. If the source material is thin, say so. Not everything needs to be a LinkedIn post.
+9. **Show the user what you're doing.** Before each tool call, briefly explain what you're about to do and why. Content creation is collaborative — the user should feel in control.
+10. **Respect the user's voice.** Refinement should sharpen, not replace. If the user's phrasing is intentional, keep it. Ask before making major tone changes.
+
+---
+
+## Quick commands
+
+These are shorthand the user might use. Interpret them as the full workflow:
+
+| User says | What to do |
+|-----------|-----------|
+| "post this to LinkedIn" | Analyze → draft → show for approval → schedule |
+| "make a carousel from this" | Analyze → draft → carousel → companion text → show → schedule |
+| "schedule for tomorrow" | Take the current draft, approve, schedule for tomorrow 9 AM |
+| "add a follow-up comment" | Generate and add a comment to the most recent post |
+| "what's scheduled?" | `linwheel_posts_list` filtered to scheduled |
+| "reshape this as a hot take" | `linwheel_reshape` with contrarian angle |
+| "refine the hook" | `linwheel_refine` focused on the opening lines |
+
+---
+
+## Example
+
+**Input**: User pastes an article about agent tool descriptions.
+
+**Workflow**:
+
+```
+1. linwheel_analyze(content="[article text]")
+   → 3 angles: "hot take on tool descriptions", "5 criteria checklist", "before/after example"
+
+2. User picks "before/after example"
+
+3. linwheel_draft(content="[article]", angle="before-after")
+   → Draft: "Most tool descriptions score 1/5. Here's what a 5/5 looks like..."
+
+4. linwheel_refine(post_id="abc123", instructions="shorter hook, add line breaks")
+   → Refined draft shown to user
+
+5. User approves
+   linwheel_post_approve(post_id="abc123")
+
+6. linwheel_post_image(post_id="abc123")
+   → Generated visual
+
+7. linwheel_post_schedule(post_id="abc123", scheduled_at="2026-03-14T09:00:00Z")
+
+8. linwheel_post_comment(post_id="abc123", body="The full rubric is open source: [link]")
+```
+
+**Output**: Scheduled LinkedIn post with image, follow-up comment queued for 30 min after publish.

--- a/skills/linwheel-content-engine/assets/flow.svg
+++ b/skills/linwheel-content-engine/assets/flow.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 160" fill="none">
+  <style>
+    .box { rx: 8; ry: 8; stroke-width: 2; }
+    .label { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; fill: #e2e8f0; text-anchor: middle; dominant-baseline: central; }
+    .sublabel { font-family: system-ui, -apple-system, sans-serif; font-size: 10px; fill: #94a3b8; text-anchor: middle; dominant-baseline: central; }
+    .arrow { stroke: #64748b; stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#64748b" />
+    </marker>
+  </defs>
+
+  <!-- Analyze -->
+  <rect x="10" y="40" width="120" height="80" class="box" fill="#1e293b" stroke="#38bdf8" />
+  <text x="70" y="70" class="label">analyze</text>
+  <text x="70" y="90" class="sublabel">source content</text>
+
+  <!-- Arrow -->
+  <line x1="130" y1="80" x2="155" y2="80" class="arrow" />
+
+  <!-- Reshape -->
+  <rect x="155" y="40" width="120" height="80" class="box" fill="#1e293b" stroke="#a78bfa" />
+  <text x="215" y="70" class="label">reshape</text>
+  <text x="215" y="90" class="sublabel">pick angles</text>
+
+  <!-- Arrow -->
+  <line x1="275" y1="80" x2="300" y2="80" class="arrow" />
+
+  <!-- Refine -->
+  <rect x="300" y="40" width="120" height="80" class="box" fill="#1e293b" stroke="#fbbf24" />
+  <text x="360" y="70" class="label">refine</text>
+  <text x="360" y="90" class="sublabel">draft + polish</text>
+
+  <!-- Arrow -->
+  <line x1="420" y1="80" x2="445" y2="80" class="arrow" />
+
+  <!-- Visuals -->
+  <rect x="445" y="40" width="120" height="80" class="box" fill="#1e293b" stroke="#f472b6" />
+  <text x="505" y="70" class="label">visuals</text>
+  <text x="505" y="90" class="sublabel">image / carousel</text>
+
+  <!-- Arrow -->
+  <line x1="565" y1="80" x2="590" y2="80" class="arrow" />
+
+  <!-- Schedule -->
+  <rect x="590" y="40" width="120" height="80" class="box" fill="#1e293b" stroke="#4ade80" />
+  <text x="650" y="70" class="label">schedule</text>
+  <text x="650" y="90" class="sublabel">approve + time</text>
+
+  <!-- Arrow -->
+  <line x1="710" y1="80" x2="735" y2="80" class="arrow" />
+
+  <!-- Comments -->
+  <rect x="735" y="40" width="150" height="80" class="box" fill="#1e293b" stroke="#4ade80" />
+  <text x="810" y="70" class="label">comments</text>
+  <text x="810" y="90" class="sublabel">follow-up + engage</text>
+</svg>


### PR DESCRIPTION
## Summary
New skill wrapping LinWheel's MCP server (`@linwheel/mcp-server`) for LinkedIn content creation.

### What's included
- **SKILL.md**: Full 22-tool orchestration guide — content creation, post management, carousels, images, scheduling, comments, voice/brand management
- **README.md**: Badges, flow SVG, install instructions, usage examples, example session
- **assets/flow.svg**: Six-stage pipeline diagram (analyze → reshape → refine → visuals → schedule → comments)
- **README.md table**: Updated with new skill entry

### Workflow
```
Source content → analyze → reshape into angles → draft + refine → generate visuals → approve + schedule → follow-up comments
```

### Security scan
```
CLEAN — 0 flagged, 0 blocked (2 INFO-level URL findings for linwheel.io domain)
```

## Test plan
- [x] `brunnr scan` passes (CLEAN)
- [x] All 78 existing tests pass
- [ ] README table renders without overflow
- [ ] Flow SVG renders on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)