### PR TITLE
ci: add ClawHub publish workflow

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -1,0 +1,85 @@
+name: Publish Skills to ClawHub
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/**'
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump level'
+        required: false
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  security-scan:
+    name: Security Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install brunnr
+        run: pip install -e .
+      - name: Run security scan
+        run: python3 tests/scan-all-skills.py
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: clawhub-scan-report
+          path: tests/artifacts/scan-report.json
+
+  publish:
+    name: Publish to ClawHub
+    needs: security-scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install clawhub CLI
+        run: npm install -g clawhub
+
+      - name: Authenticate
+        run: clawhub login --token "$CLAWHUB_TOKEN"
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+
+      - name: Verify auth
+        run: clawhub whoami
+
+      - name: Dry-run sync (preview)
+        run: |
+          clawhub sync \
+            --root skills/ \
+            --all \
+            --bump ${{ github.event.inputs.bump || 'patch' }} \
+            --dry-run \
+            --no-input
+
+      - name: Publish changed skills
+        run: |
+          clawhub sync \
+            --root skills/ \
+            --all \
+            --bump ${{ github.event.inputs.bump || 'patch' }} \
+            --tags latest \
+            --changelog "Published from brunnr main (${{ github.sha }})" \
+            --no-input
+
+      - name: Post publish summary
+        if: always()
+        run: |
+          echo "## ClawHub Publish Results" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Bump: ${{ github.event.inputs.bump || 'patch' }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- New workflow: `.github/workflows/publish-clawhub.yml`
- Triggers on push to main when `skills/**` changes
- Gates on security scan before publishing
- Uses `clawhub sync` to auto-detect and publish changed skills
- Supports `patch`/`minor`/`major` version bumps via `workflow_dispatch`

## Setup required
- Add `CLAWHUB_TOKEN` secret to the repo

## TODO: selective publish
Currently syncs all changed skills. To publish a single skill:
```bash
# Via workflow_dispatch, add a `skill` input:
clawhub publish skills/<slug> --slug <slug> --version <semver> --tags latest
```
Will add a `skill` input parameter to the workflow_dispatch so you can target one skill at a time. For now, `--dry-run` previews what would publish.

## Test plan
- [ ] Add `CLAWHUB_TOKEN` secret
- [ ] Trigger manually via `workflow_dispatch` with dry-run first

🤖 Generated with [Claude Code](https://claude.com/claude-code)